### PR TITLE
Fix xarray FutureWarning for timedelta decoding

### DIFF
--- a/edriso/initialize.py
+++ b/edriso/initialize.py
@@ -114,7 +114,11 @@ def open_grib(
     try:
         logger.info("Opening data file %s", filename)
         dataset = xr.open_dataset(
-            filename, engine="cfgrib", decode_cf=True, indexpath=indexpath
+            filename,
+            engine="cfgrib",
+            decode_cf=True,
+            decode_timedelta=True,
+            indexpath=indexpath,
         )
     except ValueError as err:
         logger.error(


### PR DESCRIPTION
Add decode_timedelta=True parameter to xr.open_dataset() to explicitly opt-in to timedelta64 decoding behavior and silence the FutureWarning.

This prevents the warning:
'In a future version of xarray decode_timedelta will default to False'

The explicit parameter ensures forward compatibility with future xarray versions while maintaining current behavior.